### PR TITLE
feat: use GITHUB_API_URL as baseUrl for octokit

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ async function main() {
 
   const octokit = new Octokit({
     auth: `token ${GITHUB_TOKEN}`,
+    baseUrl: process.env.GITHUB_API_URL || "https://api.github.com",
     userAgent: "pascalgn/size-label-action"
   });
 


### PR DESCRIPTION
Allow also to connect to GHE instances when using the API URL from the envs