### PR TITLE
chore(ci): remove actions/labeler

### DIFF
--- a/.github/workflows/pr-label.yml
+++ b/.github/workflows/pr-label.yml
@@ -19,11 +19,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-    - uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
-      with:
-        configuration-path: ".github/configs/labeler.yaml"
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
 
     - name: size-label
       uses: ./


### PR DESCRIPTION
The `actions/labeler` action is not required and will be removed from the workflow.